### PR TITLE
Switches from delitescere/docker-zulu to cantara/alpine-zulu-jdk8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-/Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ before_script:
   # Log in to Docker Hub for releasing the image
   - docker login -e abesto0+docker-zipkin-deployer@gmail.com -u dockerzipkindeployer -p "$DOCKERHUB_PASSWORD"
   # Download docker-squash
-  - curl -SL https://github.com/jwilder/docker-squash/releases/download/v0.2.0/docker-squash-linux-amd64-v0.2.0.tar.gz |tar -xvz
-  - export PATH=$PATH:$PWD
+  - pip install docker-squash
 
 # Run only for tags
 # Heuristic: tags describe versions, so they'll start with a number

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM delitescere/jdk:VERSION
+FROM cantara/alpine-zulu-jdk8
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
 # Remove 40M worth of SDK things, but link back /usr/local/java/bin to help tools

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-`openzipkin/jre-full` is a minimal but full JRE Docker image based on [delitescere/jdk](https://github.com/delitescere/docker-zulu). It's created by removing the JDK and leaving only the JRE, then squashing the Docker image.
+`openzipkin/jre-full` is a minimal but full JRE Docker image based on [cantara/alpine-zulu-jdk8](https://github.com/Cantara/maven-infrastructure/tree/master/docker-baseimages/alpine-zulu-jdk8). It's created by removing the JDK and leaving only the JRE, then squashing the Docker image.
 
 On Dockerhub: [openzipkin/jre-full](https://hub.docker.com/r/openzipkin/jre-full/)
 
 ## Release process
 
-New versions are built on [Travis CI](https://travis-ci.org/openzipkin/docker-jre-full). To trigger a build, push a new tag to GitHub. The tag will be the Docker tag assigned to the newly built image, which is exactly the same as the Docker tag from `delitescere/jdk` used as the base of the build.
+New versions are built on [Travis CI](https://travis-ci.org/openzipkin/docker-jre-full). To trigger a build, push a new tag to GitHub. The tag will be the Docker tag assigned to the newly built image. Since `cantara/alpine-zulu-jdk8` only pushes latest, name the tag according to the JDK in use. For example `1.8.0_112`.

--- a/release.sh
+++ b/release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Takes a minimal but full JDK image from delitescere/jdk
+# Takes a minimal but full JDK image from cantara/alpine-zulu-jdk8
 # Removes the JDK and keeps the full JRE
 # Then squashes to minimize the image size
 # The resulting images are expected to change rarely, if ever
@@ -17,10 +17,8 @@ fat_tag="${tag}-fat"
 
 docker_squash="$(which docker-squash)"
 
-sed "s/VERSION/$version/g" Dockerfile.in > Dockerfile
 docker build -t "$fat_tag" .
-rm Dockerfile
 
-docker save "$fat_tag" | sudo "$docker_squash" -t "$tag" | docker load
+docker-squash -t "$tag" "$fat_tag"
 
 docker push "$tag"


### PR DESCRIPTION
delitescere/docker-zulu is not actively maintained. This switches to a
maintained base layer, so that we can get JRE updates such as security
patches.