### PR TITLE
Change parent image to openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM cantara/alpine-zulu-jdk8
+FROM openjdk:8-jdk-alpine
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
 # Remove 40M worth of SDK things, but link back /usr/local/java/bin to help tools
 # that auto-detect JAVA_HOME.
 RUN rm -rf /usr/local/java/bin /usr/local/java/lib /usr/local/java/include
-# Having the rm and the ln in the same FS layer confuses docker squash
-RUN ln -s /usr/local/java/jre/bin /usr/local/java/bin
 
 # Setup curl for convenience as all derivative images use it, and putting
 # it in one layer (via squash) is helpful

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jre-alpine
 MAINTAINER OpenZipkin "http://zipkin.io/"
-
-# Remove 40M worth of SDK things, but link back /usr/local/java/bin to help tools
-# that auto-detect JAVA_HOME.
-RUN rm -rf /usr/local/java/bin /usr/local/java/lib /usr/local/java/include
 
 # Setup curl for convenience as all derivative images use it, and putting
 # it in one layer (via squash) is helpful

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-`openzipkin/jre-full` is a minimal but full JRE Docker image based on [cantara/alpine-zulu-jdk8](https://github.com/Cantara/maven-infrastructure/tree/master/docker-baseimages/alpine-zulu-jdk8). It's created by removing the JDK and leaving only the JRE, then squashing the Docker image.
+`openzipkin/jre-full` is a minimal but full JRE Docker image based on [openjdk:8-jre-alpine](https://github.com/docker-library/openjdk/blob/master/8/jdk/alpine/Dockerfile). 
 
 On Dockerhub: [openzipkin/jre-full](https://hub.docker.com/r/openzipkin/jre-full/)
 
 ## Release process
 
-New versions are built on [Travis CI](https://travis-ci.org/openzipkin/docker-jre-full). To trigger a build, push a new tag to GitHub. The tag will be the Docker tag assigned to the newly built image. Since `cantara/alpine-zulu-jdk8` only pushes latest, name the tag according to the JDK in use. For example `1.8.0_112`.
+New versions are built on [Travis CI](https://travis-ci.org/openzipkin/docker-jre-full). To trigger a build, push a new tag to GitHub. The tag will be the Docker tag assigned to the newly built image. Name the tag according to the JDK in use. For example `1.8.0_112`.

--- a/release.sh
+++ b/release.sh
@@ -13,12 +13,7 @@ if [[ $# -ne 1 ]]; then
 fi
 version="$1"
 tag="openzipkin/jre-full:$version"
-fat_tag="${tag}-fat"
 
-docker_squash="$(which docker-squash)"
-
-docker build -t "$fat_tag" .
-
-docker-squash -t "$tag" "$fat_tag"
+docker build --squash -t "$tag" .
 
 docker push "$tag"


### PR DESCRIPTION
The official openjdk image is based on alpine, it is smaller than
the openjdk built by cantara.
Additionally, it supports multi-arch image and it allows to build the zipkin
docker images for other architectures.

Signed-off-by: Alice Frosi <alice@linux.vnet.ibm.com>