### PR TITLE
Update to Alpine-OpenJDK version 1.8.0_191

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:8u191-jre-alpine3.8
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
 # Add edge repo, needed for tools downstream like runit


### PR DESCRIPTION
I'd prefer the simple creation of a new Tag "1.8.0_191" on master on order to pull to current `openjdk:8-jre-alpine` image (updated 3 days ago to JRE version `1.8.0_191`, see: https://hub.docker.com/_/openjdk).