### PR TITLE
Add support in base image for JDK crypto using elliptic curve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ java.management,\
 jdk.management.agent,\
 # non-netty based DNS
 java.naming,jdk.naming.dns,\
+# TLS handehake with servers that use elliptic curve certificates
+jdk.crypto.ec,\
 # sun.misc.Unsafe and friends
 jdk.unsupported\
  --output jre


### PR DESCRIPTION
I found in a different project using a similarly slim JRE image that this module is required to use Java TLS and elliptic curve.

https://stackoverflow.com/questions/54770538/received-fatal-alert-handshake-failure-in-jlinked-jre

While we usually use OpenSSL with Armeria clients, we do have some non-netty fetching (e.g., GCP access token) that could fail if the server doesn't support RSA. I think it's good to have this.