### PR TITLE
Add instrumentation and remote debug modules to base JRE.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,12 @@ RUN cd / && jlink --no-header-files --no-man-pages --compress=0 --strip-debug \
 java.desktop,\
 # our default server includes SQL
 java.sql,\
+# instrumentation
+java.instrument,\
 # we don't use JMX, but log4j2 errors without it: LOG4J2-716
 java.management,\
+# remote debug
+jdk.jdwp.agent,\
 # prevents us from needing a different base layer for kafka-zookeeper
 # ZooKeeper needs jdk.management.agent, and adding it is 900K vs 200M for a different base layer
 jdk.management.agent,\


### PR DESCRIPTION
Instrumentation can be useful for allowing edge cases without explicit support in zipkin (like https://github.com/openzipkin/zipkin/issues/2909) and remote debug can be useful when debugging the docker image, which I have wanted to do before. Adds 200K.