### PR TITLE
Add jdk.management to docker JRE to enable most JVM metrics exported …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ java.instrument,\
 java.management,\
 # remote debug
 jdk.jdwp.agent,\
+# JVM metrics such as garbage collection
+jdk.management,\
 # prevents us from needing a different base layer for kafka-zookeeper
 # ZooKeeper needs jdk.management.agent, and adding it is 900K vs 200M for a different base layer
 jdk.management.agent,\


### PR DESCRIPTION
…by micrometer.

Noticed there weren't GC metrics in `ServerIntegratedBenchmark` and found this. It's an important module.

https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/package-summary.html