### PR TITLE
Updates JRE to 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-debian:13 AS jre
+FROM azul/zulu-openjdk-debian:14 AS jre
 
 # Needed for --strip-debug
 RUN apt-get -y update && apt-get -y install binutils


### PR DESCRIPTION
```bash
openjdk 14.0.1 2020-04-14
OpenJDK Runtime Environment Zulu14.28+21-CA (build 14.0.1+8)
OpenJDK 64-Bit Server VM Zulu14.28+21-CA (build 14.0.1+8, mixed mode)
```