### PR TITLE
Inlines abandoned alpine image so it can update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
-FROM openjdk:8-jre-alpine
+FROM alpine:3.12
+
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
-# Add edge repo, needed for tools downstream like runit
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
-# Avoid warning: This apk-tools is OLD!
-RUN apk add --upgrade --no-cache apk-tools
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
 
-# Setup curl and bash for convenience as all derivative images use it
-RUN apk add --update --no-cache curl bash apk-tools
+# Add edge repo, needed for latest JRE and tools downstream like runit
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+
+# Setup curl as all derivative images use it
+RUN apk add --upgrade --no-cache openjdk8-jre curl
 
 # Java relies on /etc/nsswitch.conf. Put host files first or InetAddress.getLocalHost
 # will throw UnknownHostException as the local hostname isn't in DNS.
 RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
-
-# Dependent images all assume bash, so let's set that here
-SHELL ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ ENV LANG C.UTF-8
 # Add edge repo, needed for latest JRE and tools downstream like runit
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 
-# Setup curl as all derivative images use it
-RUN apk add --upgrade --no-cache openjdk8-jre curl
+# Update JRE to latest patch
+RUN apk add --upgrade --no-cache openjdk8-jre
 
 # Java relies on /etc/nsswitch.conf. Put host files first or InetAddress.getLocalHost
 # will throw UnknownHostException as the local hostname isn't in DNS.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
-`openzipkin/jre-full` is a minimal but full JRE Docker image based on [openjdk:8-jre-alpine](https://github.com/docker-library/openjdk/blob/master/8/jdk/alpine/Dockerfile). 
+`openzipkin/jre-full` is a minimal but full Alpine JRE Docker 1.8 image.
 
 On Dockerhub: [openzipkin/jre-full](https://hub.docker.com/r/openzipkin/jre-full/)
 
 ## Release process
 
-New versions are built on [Travis CI](https://travis-ci.org/openzipkin/docker-jre-full). To trigger a build, push a new tag to GitHub. The tag will be the Docker tag assigned to the newly built image. Name the tag according to the JDK in use. For example `1.8.0_112`.
+New versions are built on [Travis CI](https://travis-ci.org/openzipkin/docker-jre-full). To trigger a build, push a new tag to GitHub. The tag will be the Docker tag assigned to the newly built image. Name the tag according to the JDK in use.
+
+The tag will be the Docker tag assigned to the newly built image. Name the tag according to the JDK variant use.
+
+For example, with the following output from `docker run (image built) -version`:
+```
+openjdk version "1.8.0_252"
+OpenJDK Runtime Environment (IcedTea 3.16.0) (Alpine 8.252.09-r0)
+OpenJDK 64-Bit Server VM (build 25.252-b09, mixed mode)
+```
+
+You would name the tag `1.8.0_252`.


### PR DESCRIPTION
openjdk stopped pushing an alpine based image, but alpine has been updating JRE 1.8

https://github.com/docker-library/openjdk/commit/3eb0351b208d739fac35345c85e3c6237c2114ec#diff-17b0a72d5a10e24142544a9dbc8effcb

I tested this with cassandra and zipkin-dependencies