### PR TITLE
Lie less, work less, by just using /jre as the JAVA_HOME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 #
 # You can choose to lint this via the following command:
 # docker run --rm -i hadolint/hadolint < Dockerfile
+
+# Since Distroless is Debian based, we take an updated JRE from Zulu's Debian image
 FROM azul/zulu-openjdk-debian:14 AS jre
 
 # Needed for --strip-debug
@@ -49,14 +51,13 @@ LABEL MAINTAINER Zipkin "https://zipkin.io/"
 RUN ["/busybox/sh", "-c", "ln -s /busybox/sh /bin/sh"]
 
 COPY --from=deps /etc/ssl/certs/java /etc/ssl/certs/java
-
 COPY --from=deps /lib/x86_64-linux-gnu/libz.so.1.2.8 /lib/x86_64-linux-gnu/libz.so.1.2.8
 RUN ln -s /lib/x86_64-linux-gnu/libz.so.1.2.8 /lib/x86_64-linux-gnu/libz.so.1
 
-COPY --from=jre /jre /usr/lib/jvm/zulu-11-amd64-slim
-RUN ln -s /usr/lib/jvm/zulu-11-amd64-slim/bin/java /usr/bin/java
+COPY --from=jre /jre /jre
 
-# set JAVA_HOME for Elasticsearch 6.x
-ENV JAVA_HOME=/usr/lib/jvm/zulu-11-amd64-slim
+# Zulu installs the JRE under /jre. Setup the JAVA_HOME and ensure it is in the PATH
+ENV JAVA_HOME=/jre
+RUN ln -s ${JAVA_HOME}/bin/java /usr/bin/java
 
 ENTRYPOINT ["/usr/bin/java", "-jar"]

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ New versions are built on [Travis CI](https://travis-ci.org/openzipkin/docker-jr
 
 For example, with the following output from `docker run (image built) -version`:
 ```
-openjdk version "11.0.4" 2019-07-16 LTS
-OpenJDK Runtime Environment Zulu11.33+15-CA (build 11.0.4+11-LTS)
-OpenJDK 64-Bit Server VM Zulu11.33+15-CA (build 11.0.4+11-LTS, mixed mode)
+openjdk version "14.0.2" 2020-07-14
+OpenJDK Runtime Environment Zulu14.29+23-CA (build 14.0.2+12)
+OpenJDK 64-Bit Server VM Zulu14.29+23-CA (build 14.0.2+12, mixed mode)
 ```
 
-You would name the tag `11.0.4-11.33`, which corresponds to the Zulu directory https://github.com/zulu-openjdk/zulu-openjdk/tree/master/11.0.4-11.33
+You would name the tag `14.0.2-14.29.23`, which makes sense as it corresponds to...
+ * Zulu's most-specific tag the JRE image https://hub.docker.com/r/azul/zulu-openjdk-debian/tags?page=1&name=14
+ * Zulu source directory of their Dockerfile https://github.com/zulu-openjdk/zulu-openjdk/tree/master/14.0.2-14.29.23


### PR DESCRIPTION
Before, we lied a bit by pretending we knew the JRE during the Docker
build. Rather than trying to name the directory according to version,
this just uses the same convention as upstream: `/jre`.

This also adds more notes about the source image.