### PR TITLE
Updates to JDK 15 via Alpine, saving complexity and about 15MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,13 @@
 # You can choose to lint this via the following command:
 # docker run --rm -i hadolint/hadolint < Dockerfile
 
-FROM alpine:3.12 as install
+# Get latest JDK 15: we will later use jlink to create a smaller JRE than the default (200MB)
+FROM azul/zulu-openjdk-alpine:15 as install
 
 WORKDIR /install
 
-# Install latest JDK 15: we will later use jlink to create a smaller JRE than the default (200MB)
-RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/
-RUN echo https://repos.azul.com/zulu/alpine >> /etc/apk/repositories
 #   binutils is needed for --strip-debug
-RUN apk add --no-cache zulu15-jdk binutils
+RUN apk add --no-cache binutils
 
 # Included modules cherrypicked from https://docs.oracle.com/en/java/javase/11/docs/api/
 RUN /usr/lib/jvm/zulu15-ca/bin/jlink --no-header-files --no-man-pages --compress=0 --strip-debug --add-modules \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM alpine:3.12 as install
 
 WORKDIR /install
 
-# Install latest JDK 15, which we will use link to create a smaller JRE than the default (200MB)
+# Install latest JDK 15: we will later use jlink to create a smaller JRE than the default (200MB)
 RUN wget --quiet https://cdn.azul.com/public_keys/alpine-signing@azul.com-5d5dc44c.rsa.pub -P /etc/apk/keys/
 RUN echo https://repos.azul.com/zulu/alpine >> /etc/apk/repositories
 #   binutils is needed for --strip-debug

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ MAINTAINER OpenZipkin "http://zipkin.io/"
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+# Allow boringssl for Netty per https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty
+RUN apk add --no-cache libc6-compat
+
 # Java relies on /etc/nsswitch.conf. Put host files first or InetAddress.getLocalHost
 # will throw UnknownHostException as the local hostname isn't in DNS.
 RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /install
 #   binutils is needed for --strip-debug
 RUN apk add --no-cache binutils
 
-# Included modules cherrypicked from https://docs.oracle.com/en/java/javase/11/docs/api/
+# Included modules cherrypicked from https://docs.oracle.com/en/java/javase/15/docs/api/
 RUN /usr/lib/jvm/zulu15-ca/bin/jlink --no-header-files --no-man-pages --compress=0 --strip-debug --add-modules \
 java.base,java.logging,\
 # java.desktop includes java.beans which is used by Spring

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -26,9 +26,11 @@ openzipkin/jre-full                  alpine              128317d6038e        20 
 openzipkin/jre-full                  distroless          0717ad881158        3 minutes ago       102MB
 ```
 
-### We are ok not having BoringSSL in the default image
+### We are still smaller adding BoringSSL support
 
-BoringSSL is not formally supported on Alpine (citation needed). We used to rely
-on this to provide ALPN support needed for zipkin-gcp integration. Since then,
-all recent Zulu builds support ALPN, so we no longer have a hard need for it.
-For example, even JDK 1.8 supports ALPN since 8u252.
+Some applications like gRPC prefer use of BoringSSL over default TLS libraries.
+To support `netty-tcnative-boringssl-static` on Distroless, there are no special
+instructions. However, for Alpine we need to install `libc6-compat` per [https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty].
+
+While the additional package increases our distribution by 600KB, it is still
+almost 15MB smaller than using Distroless.

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -1,24 +1,34 @@
 # zipkin-docker-jre rationale
 
-## Why do we link /bin/sh to BusyBox?
+## Why do we use Alpine Linux instead of Distroless?
 
-It is possible to override some Docker commands to use something besides
-`/bin/sh`, notably to allow use of `/busybox/sh` included in Alpine and
-Distroless debug images:
+### We need a working /bin/sh
 
-Ex.
-```diff
--ENTRYPOINT ["/busybox/sh", "run.sh"]
-+ENTRYPOINT run.sh
+Alpine Linux includes `/busybox/sh`, linked to `/bin/sh`. This allows us to
+customize startup and add HEALTHCHECK instructions. Notably, Alpine linking
+`/bin/sh` allows docker-compose to override health checks as necessary. This is
+because docker-compose always invokes its health check overrides with
+`/bin/sh -c`.
+
+It is possible to layer BusyBox on a distroless image to perform the same, but
+Alpine does this by default.
+
+### We want the smallest base image
+
+We are often criticized for the size of our sDdocker image, as it is an ancillary
+part of people's environments. Zipkin's 'slim' build is currently a 26MB jar
+file. The bulk of the size left is the JRE. Here's a comparison of size between
+a comparible build of the same JRE, one with Distroless (Debian based) and the
+other Alpine.
+
+```
+openzipkin/jre-full                  alpine              128317d6038e        20 seconds ago      87.1MB
+openzipkin/jre-full                  distroless          0717ad881158        3 minutes ago       102MB
 ```
 
-However, there are some inconsistencies. For example, it is possible to override
-docker-compose health-check to use a different shell, but not in Dockerfile
-syntax (always invokes with `/bin/sh -c`).
+### We are ok not having BoringSSL in the default image
 
-These nuances are very hard to hunt down and require experience to figure out.
-Meanwhile, there's little security given by intentionally not making `/bin/sh`
-work when `/bin/busybox` exists. To allow the least configuration distration,
-and the highest amount of commands to work, we link `/bin/sh` to BusyBox
-regardless of whether we are using Alpine (which does this by default) or
-Distroless, which doesn't.
+BoringSSL is not formally supported on Alpine (citation needed). We used to rely
+on this to provide ALPN support needed for zipkin-gcp integration. Since then,
+all recent Zulu builds support ALPN, so we no longer have a hard need for it.
+For example, even JDK 1.8 supports ALPN since 8u252.

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -15,7 +15,7 @@ Alpine does this by default.
 
 ### We want the smallest base image
 
-We are often criticized for the size of our sDdocker image, as it is an ancillary
+We are often criticized for the size of our Docker image, as it is an ancillary
 part of people's environments. Zipkin's 'slim' build is currently a 26MB jar
 file. The bulk of the size left is the JRE. Here's a comparison of size between
 a comparible build of the same JRE, one with Distroless (Debian based) and the

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-`openzipkin/jre-full` is a minimal but full [distroless JRE Docker image](https://github.com/GoogleContainerTools/distroless) based on [azul/zulu-openjdk-debian](https://github.com/zulu-openjdk/zulu-openjdk/tree/master/debian/11-latest).
+`openzipkin/jre-full` is a minimal JRE Docker image based on [azul/zulu-openjdk-alpine](https://hub.docker.com/r/azul/zulu-openjdk-alpine).
 
 On Dockerhub: [openzipkin/jre-full](https://hub.docker.com/r/openzipkin/jre-full/)
 
@@ -8,14 +8,13 @@ New versions are built on [Travis CI](https://travis-ci.org/openzipkin/docker-jr
 
 For example, with the following output from `docker run --rm (image built) -version`:
 ```
-openjdk version "14.0.2" 2020-07-14
-OpenJDK Runtime Environment Zulu14.29+23-CA (build 14.0.2+12)
-OpenJDK 64-Bit Server VM Zulu14.29+23-CA (build 14.0.2+12, mixed mode)
+openjdk version "15" 2020-09-15
+OpenJDK Runtime Environment Zulu15.27+17-CA (build 15+36)
+OpenJDK 64-Bit Server VM Zulu15.27+17-CA (build 15+36, mixed mode)
 ```
 
-You would name the tag `14.0.2-14.29.23`, which makes sense as it corresponds to...
- * Zulu's most-specific tag the JRE image https://hub.docker.com/r/azul/zulu-openjdk-debian/tags?page=1&name=14
- * Zulu source directory of their Dockerfile https://github.com/zulu-openjdk/zulu-openjdk/tree/master/14.0.2-14.29.23
+You would name the tag `15.0.0-15.27.17`, which makes sense as it corresponds to...
+ * Zulu's most-specific tag the JRE image https://hub.docker.com/r/azul/zulu-openjdk-alpine/tags?page=1&name=15
 
 Note: The upstream Zulu repository has a monthly release cadence. Maintainers should [watch the repo](https://github.com/zulu-openjdk/zulu-openjdk/watchers),
 in case a pull request corresponds to a release. Since not all releases correspond to pull requests,


### PR DESCRIPTION
Zulu didn't have Alpine builds for a while. Now, we have Alpine 15.
Using this simplifies the Dockerfile and saves a large percentage of our
base image. This implies we don't have BoringSSL anymore, but we don't
need it recently as ALPN has worked for quite a while.